### PR TITLE
Feat : 갹 Feed CRD(전체조회, 상세조회, 생성,삭제)에 User모델 인증 추가

### DIFF
--- a/OB_instargram/settings.py
+++ b/OB_instargram/settings.py
@@ -138,3 +138,6 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     )
 }
+
+#Message framework 사용시 지정
+MESSAGE_STORAGE = 'django.contrib.messages.storage.cookie.CookieStorage'

--- a/sns/views.py
+++ b/sns/views.py
@@ -1,32 +1,21 @@
-'''
-# 로그인 페이지 - 인걸
-from rest_framework.views import APIView
-from user.models import User
-
-
-class Index(APIView):
-    def get(self, request):
-        email = request.session.get('email', None)
-        user = User.objects.filter(email=email).first()
-
-        if email is None:
-            return redirect('signin')
-        elif user is None:
-            return redirect('signin')
-        else:
-            return render(request, 'sns/index.html')
-'''
-
 from django.http import HttpResponse
 from django.shortcuts import render, redirect
 from .models import Feed
 from .models import FeedComment
+from django.contrib.auth.decorators import login_required
+from django.contrib import messages
+
 # # 메인
 def main(request):
-    all_feed = Feed.objects.all().order_by('-created_at')
-    return render(request, 'sns/index.html', {'feeds': all_feed})
+    user = request.user.is_authenticated
+    if user:
+        all_feed = Feed.objects.all().order_by('-created_at')
+        return render(request, 'sns/index.html', {'feeds': all_feed})
+    else:
+        return redirect('/signin')
   
 # 특정 피드 - 현지
+@login_required
 def feed_detail(request,id):
     target_feed = Feed.objects.get(id=id)
     each_comment = FeedComment.objects.filter(feed_id=id)
@@ -34,30 +23,26 @@ def feed_detail(request,id):
     return render(request, 'sns/feed.html',  {'feed': target_feed , 'comments':each_comment })
 
 # 피드 작성 - 승주님
+@login_required
 def feed_create(request):
-    # if request.method == 'GET':
-    #     return render(request, 'sns/index.html')  
-    # #     my_create.auther = request.my_create.auther
-    # #     if :  # 로그인 한 사용자라면
-    # #         return render(request, 'sns/index.html')
-        
-    # #     else:  # 로그인이 되어 있지 않다면
-    # #         return redirect('/sign-in')
-
     if request.method == 'GET':
-        return redirect ( '/') 
+        return redirect ('/') 
 
     elif request.method == 'POST':
-        my_author= "승주"
+        my_author= request.user
 
         new_feed = Feed()
         new_feed.author = my_author
         new_feed.content = request.POST.get('my-content')
         new_feed.save()
 
-        return redirect ( '/') 
-        
-# # @login-message_required
+        # 피드 작성후 작성한 피드 상세페이지로 이동
+        new_feed_id = Feed.objects.last().id
+        messages.add_message(request,messages.SUCCESS,'게시글이 작성되었습니다.')
+        return redirect (f'/feed/{new_feed_id}')
+
+# 피드 수정 - 승주님       
+@login_required
 def feed_update(request, id):
     feed = Feed.objects.get(id=id)
     if request.method == 'POST':
@@ -66,18 +51,30 @@ def feed_update(request, id):
         update_feed= request.POST.get('my-content')
         
         update_feed.save()
+        
         return render(request, 'index.html')
     else:
        return redirect ('/') 
 
 # 피드 삭제 - 현지님
+@login_required
 def feed_delete(request,id):
     target_feed = Feed.objects.get(id=id)
-    target_feed.delete()
-    return redirect('/')
+    # 게시물 작성자, 관리자만 삭제 가능
+    if (target_feed.author == request.user.username):
+        target_feed.delete()
+        messages.add_message(request,messages.SUCCESS,'삭제되었습니다.')
+        return redirect('/')
+    elif request.user.is_staff:
+        target_feed.delete()
+        messages.add_message(request,messages.SUCCESS,'관리자 권한으로 삭제되었습니다.')
+        return redirect('/')
+    else:
+        messages.add_message(request,messages.ERROR,'본인 게시글이 아닙니다.')
+        return redirect(f'/feed/{id}') 
+
 
 # 댓글 - 상훈
-
 def write_comment(request, id):
     if request.method == 'POST':
         # request 데이터 받기

--- a/static/css/sns.css
+++ b/static/css/sns.css
@@ -281,7 +281,20 @@ ul.follow_list>li{
 }
 
 /* feed more */
-#feedMoreModel button.btn_modal_feedmore{
+.moreModel .modal-body{
+    text-align: center;
+    border-bottom: 1px solid rgb(219, 219, 219);
+    padding: 32px 0;
+}
+.moreModel .modal_title{
+    font-size: 1.25em;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+.moreModel .modal-footer{
+    border:0;
+}
+.moreModel button.btn_modal_feedmore, .moreModel button.btn_modal_feedmore:hover{
     width: 100%;
     border-top: 1px solid rgb(219,219,219);
     line-height: 1.5;
@@ -289,11 +302,12 @@ ul.follow_list>li{
     text-align: center;
     vertical-align: middle;
     border-radius: 0;
+    margin:0;
 }
-#feedMoreModel button.btn_modal_feedmore:first-child{
+.moreModel button.btn_modal_feedmore:first-child{
     border-top:0;
 }
-#feedMoreModel button.btn_modal_feedmore.red{
+.moreModel button.btn_modal_feedmore.red{
     color: #ed4956;
     font-weight: 600;
 }

--- a/static/js/feed.js
+++ b/static/js/feed.js
@@ -1,10 +1,23 @@
 // card_feed 모달 
 $('#feedMoreModel').on('show.bs.modal', function(event) {          
     target_id = $(event.relatedTarget).data('notifyid');
-    console.log(target_id)
+    target_auth = $(event.relatedTarget).data('auth');
 
+    if(target_auth){
+       
+        $(this).find(".btn_edit").show();
+        $(this).find(".btn_deletemodel").show();
+        $(this).find(".btn_unfollow").hide();
+    }else{
+        $(this).find(".btn_edit").hide();
+        $(this).find(".btn_deletemodel").hide();
+        $(this).find(".btn_unfollow").show();
+    }
     $(this).attr("data-target",target_id);
-
-    $(this).find(".btn_delete").attr("onclick","location.href='/feed/delete/"+target_id+"'");
     $(this).find(".btn_goFeed").attr("onclick","location.href='/feed/"+target_id+"'");
+});
+
+$('#deleteModal').on('show.bs.modal', function(event) {     
+    target_id = $(event.relatedTarget).closest(".modal").attr("data-target")
+    $(this).find(".btn_delete").attr("onclick","location.href='/feed/delete/"+target_id+"'");
 });

--- a/templates/sns/feed.html
+++ b/templates/sns/feed.html
@@ -25,7 +25,7 @@
                             </div>
                         </div>
                         <div class="card_btn">
-                            <button type="button" class="btn btn_card_more" data-bs-toggle="modal" data-notifyid="{{ feed.id }}" data-bs-target="#feedMoreModel">
+                            <button type="button" class="btn btn_card_more" data-notifyid="{{ feed.id }}" data-bs-toggle="modal" {% if user.username == feed.author %}data-auth="true"{% else %}data-auth="false"{% endif %} data-bs-target="#feedMoreModel">
                                 <svg aria-label="More options" class="_ab6-" color="#262626" fill="#262626" height="24" role="img" viewBox="0 0 24 24" width="24"><circle cx="12" cy="12" r="1.5"></circle><circle cx="6" cy="12" r="1.5"></circle><circle cx="18" cy="12" r="1.5"></circle></svg>
                             </button>
                         </div>
@@ -119,12 +119,12 @@
         </div>
     </section>
     <!-- Modal -->
-    <div class="modal fade" id="feedMoreModel" tabindex="-1" aria-labelledby="feedMoreModelLabel" aria-hidden="true">
+    <div class="modal fade moreModel" id="feedMoreModel" tabindex="-1" aria-labelledby="feedMoreModelLabel" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
-                <div class="modal-body flex flex_column p-0">
-                    <button type="button" class="btn btn_modal_feedmore btn_delete red" data-bs-dismiss="modal" aria-label="Delete">Delete</button>
-                    <button type="button" class="btn btn_modal_feedmore btn_Edit red" data-bs-toggle="modal" data-bs-target="#staticBackdrop" aria-label="Edit">Edit</button>
+                <div class="modal-footer flex flex_column p-0">
+                    <button type="button" class="btn btn_modal_feedmore btn_edit red" data-bs-toggle="modal" data-bs-target="#staticBackdrop" aria-label="Edit">Edit</button>
+                    <button type="button" class="btn btn_modal_feedmore btn_deletemodel red" data-bs-toggle="modal" data-bs-target="#deleteModal" aria-label="Edit">Delete</button>                    
                     <button type="button" class="btn btn_modal_feedmore btn_unfollow red" data-bs-dismiss="modal" aria-label="Unfollow">Unfollow</button>
                     <button type="button" class="btn btn_modal_feedmore btn_like" data-bs-dismiss="modal" aria-label="Add to favorites">Add to favorites</button>
                     <button type="button" class="btn btn_modal_feedmore btn_goFeed" data-bs-dismiss="modal" aria-label="Go to post">Go to post</button>
@@ -133,8 +133,29 @@
             </div>
         </div>
     </div>
+    <div class="modal fade moreModel" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-body flex flex_column">
+                    <h5 class="modal_title">Delete Post?</h5>
+                    <p>Are you sure you want to delete this post?</p>
+                </div>
+                <div class="modal-footer flex flex_column p-0">
+                    <button type="button" class="btn btn_modal_feedmore btn_delete red" data-bs-dismiss="modal" aria-label="Delete">Delete</button>
+                    <button type="button" class="btn btn_modal_feedmore btn_close" data-bs-dismiss="modal" aria-label="Cancle">Cancle</button>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
 {% block extra_body %}
-<script src="{% static 'js/feed.js' %}"></script>
+    {% if messages %}
+        {% for message in messages %}
+            <script>
+                alert("{{ message }}");
+            </script>
+        {% endfor %}
+    {% endif %}
+    <script src="{% static 'js/feed.js' %}"></script>
 {% endblock %}

--- a/templates/sns/index.html
+++ b/templates/sns/index.html
@@ -54,7 +54,7 @@
                                 </div>
                             </div>
                             <div class="card_btn">
-                                <button type="button" class="btn btn_card_more" data-notifyid="{{feed.id}}" data-bs-toggle="modal" data-bs-target="#feedMoreModel">
+                                <button type="button" class="btn btn_card_more" data-notifyid="{{ feed.id }}" data-bs-toggle="modal" {% if user.username == feed.author %}data-auth="true"{% else %}data-auth="false"{% endif %} data-bs-target="#feedMoreModel">
                                     <svg aria-label="More options" class="_ab6-" color="#262626" fill="#262626" height="24" role="img" viewBox="0 0 24 24" width="24"><circle cx="12" cy="12" r="1.5"></circle><circle cx="6" cy="12" r="1.5"></circle><circle cx="18" cy="12" r="1.5"></circle></svg>
                                 </button>
                             </div>
@@ -212,12 +212,12 @@
     </div>
 
     <!-- Modal -->
-    <div class="modal fade" id="feedMoreModel" tabindex="-1" aria-labelledby="feedMoreModelLabel" aria-hidden="true">
+    <div class="modal fade moreModel" id="feedMoreModel" tabindex="-1" aria-labelledby="feedMoreModelLabel" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
-                <div class="modal-body flex flex_column p-0">
-                    <button type="button" class="btn btn_modal_feedmore btn_delete red" data-bs-dismiss="modal" aria-label="Delete">Delete</button>
-                    <button type="button" class="btn btn_modal_feedmore btn_Edit red" data-bs-toggle="modal" data-bs-target="#staticBackdrop" aria-label="Edit">Edit</button>
+                <div class="modal-footer flex flex_column p-0">
+                    <button type="button" class="btn btn_modal_feedmore btn_edit red" data-bs-toggle="modal" data-bs-target="#staticBackdrop" aria-label="Edit">Edit</button>
+                    <button type="button" class="btn btn_modal_feedmore btn_deletemodel red" data-bs-toggle="modal" data-bs-target="#deleteModal" aria-label="Edit">Delete</button>                    
                     <button type="button" class="btn btn_modal_feedmore btn_unfollow red" data-bs-dismiss="modal" aria-label="Unfollow">Unfollow</button>
                     <button type="button" class="btn btn_modal_feedmore btn_like" data-bs-dismiss="modal" aria-label="Add to favorites">Add to favorites</button>
                     <button type="button" class="btn btn_modal_feedmore btn_goFeed" data-bs-dismiss="modal" aria-label="Go to post">Go to post</button>
@@ -226,9 +226,29 @@
             </div>
         </div>
     </div>
+    <div class="modal fade moreModel" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-body flex flex_column">
+                    <h5 class="modal_title">Delete Post?</h5>
+                    <p>Are you sure you want to delete this post?</p>
+                </div>
+                <div class="modal-footer flex flex_column p-0">
+                    <button type="button" class="btn btn_modal_feedmore btn_delete red" data-bs-dismiss="modal" aria-label="Delete">Delete</button>
+                    <button type="button" class="btn btn_modal_feedmore btn_close" data-bs-dismiss="modal" aria-label="Cancle">Cancle</button>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
 {% block extra_body %}
-
+    {% if messages %}
+        {% for message in messages %}
+            <script>
+                alert("{{ message }}");
+            </script>
+        {% endfor %}
+    {% endif %}
 <script src="{% static 'js/feed.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fead-feature/9-feedAuth -> feedLogin

### 변경 사항
1. 메인페이지에서 로그인여부 판별 - 로그인 후 : url("/") 메인페이지 - 로그인 전 : url("/signin") 로그인페이지

2. 메인페이지 제외하고 로그아웃 유저 접근 막음

3. Feed 생성시 feed.author를 user.username으로 설정

4. Feed 생성시 "/" 아닌  피드상세페이지로 이동
- 생성시 "게시글이 작성되었습니다." 메세지 출력

5. Feed 삭제시 feed.author 혹은 관리자에게만 삭제 권한 부여
 - user권한에 따라서 feed 삭제 모달 형태가 변경 - 삭제후 message 출력 ( message framework 사용, settings.py 변경 )

### 테스트 결과
Feed 삭제시 본인 게시글일때
![Screen Shot 2022-10-06 at 12 53 53 AM](https://user-images.githubusercontent.com/12287842/194106998-a428c6bd-f933-499e-b1c3-2299faa28ef8
![Screen Shot 2022-10-06 at 12 54 16 AM](https://user-images.githubusercontent.com/12287842/194107180-8bc052a4-7310-44c7-ad94-3b9ce878c99e.png)

Feed 삭제시 본인 게시글이 아닐때
![Screen Shot 2022-10-06 at 12 53 58 AM](https://user-images.githubusercontent.com/12287842/194107126-7a3a4437-6fa1-4402-8443-1cbf09a3bac5.png)
.png)

Feed 삭제나 생성시 메세지 출력
![Screen Shot 2022-10-06 at 12 54 21 AM](https://user-images.githubusercontent.com/12287842/194107230-6b3f22eb-9844-46e1-8695-a01f5d2911d6.png)





