### PR TITLE
회원가입 시 username 정규식 추가 적용

### DIFF
--- a/user/views.py
+++ b/user/views.py
@@ -48,6 +48,7 @@ class Signup(APIView):
         # 회원가입 정규식 체크
         REGEX_EMAIL = '([A-Za-z0-9]+[.-_])*[A-Za-z0-9]+@[A-Za-z0-9-]+(\.[A-Z|a-z]{2,})+'
         REGEX_PASSWORD = '^(?=.*[\d])(?=.*[a-zA-Z])(?=.*[!@#$%^&*()])[\w\d!@#$%^&*()]{8,16}$'
+        REGEX_USERNAME = '^([a-z0-9]{4,12})$'
 
         if User.objects.filter(email=email).exists():
             return Response(status=500, data=dict(message="해당 이메일 주소가 존재합니다."))
@@ -57,6 +58,8 @@ class Signup(APIView):
             return Response(status=500, data=dict(message="이메일 형식을 확인하세요."))        
         elif not fullmatch(REGEX_PASSWORD, password):
             return Response(status=500, data=dict(message="비밀번호는 8~16자리의 영문, 숫자, 특수문자 조합만 가능합니다."))
+        elif not fullmatch(REGEX_USERNAME, username):
+            return Response(status=500, data=dict(message="사용자 이름은 최대 4~12자리의 영문, 숫자만 가능합니다."))
         else:
             make_password(password)
             User.objects.create(password=make_password(password),


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [ ]  기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
signin -> master

### 변경 사항
- 회원가입 시 username 정규식 누락으로 한글 및 특수 문자도 입력 가능한 버그 발견 > 4~12자리의 영문, 숫자, 영문+숫자 조합의 정규식 적용

### 테스트 결과
1. 정규식 매치 X
![image](https://user-images.githubusercontent.com/113072964/194109263-587e33cd-5224-4492-8407-186486dc1b43.png)
2. 정규식 매치 O
![image](https://user-images.githubusercontent.com/113072964/194109406-dbac4d80-cd0e-4a18-98c5-911951e19970.png)